### PR TITLE
Fix: Correct syntax error in content generation script

### DIFF
--- a/scripts/generateContentData.js
+++ b/scripts/generateContentData.js
@@ -1,10 +1,11 @@
 import fs from 'fs';
-console.log("Attempting to refactor generateContentData.js"); // Test line
 import path from 'path';
 import matter from 'gray-matter';
 import { marked } from 'marked';
 import readingTime from 'reading-time';
 import { execSync } from 'child_process';
+
+console.log("Attempting to refactor generateContentData.js"); // Test line
 
 const BLOG_DIR = 'content/blog';
 const JOURNEY_DIR = 'content/journey';


### PR DESCRIPTION
The `generateContentData.js` script had a `console.log` statement before its import statements, which is a syntax error in ES modules. This error likely prevented the script from executing correctly, leading to missing or stale content data for your website.

This commit moves the console.log statement to after the imports, allowing the script to run and generate the necessary data files for your application. This should resolve the issue of your website displaying a blank page.